### PR TITLE
File/Image Attachments section link is broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ sphinxalchemy_
 
 
 File and Image Attachments
-----------------------
+--------------------------
 
 SQLAlchemy-ImageAttach_
    SQLAlchemy-ImageAttach is a SQLAlchemy extension for attaching images


### PR DESCRIPTION
I think reStructuredText or github can't recognize slash charater when it is became hyperlink. So I try to use `and` instead of using slash character.
