### PR TITLE
update FormAlchemy URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ WTForms-Alchemy_
 .. _Colander: http://docs.pylonsproject.org/projects/colander/
 .. _ColanderAlchemy: https://github.com/stefanofontanelli/ColanderAlchemy
 .. _Deform: http://docs.pylonsproject.org/projects/deform/
-.. _FormAlchemy: http://formalchemy.org/
+.. _FormAlchemy: https://github.com/FormAlchemy/formalchemy
 .. _WTForms: https://wtforms.readthedocs.org/
 .. _WTForms-Alchemy: https://wtforms-alchemy.readthedocs.org/
 


### PR DESCRIPTION
- http://formalchemy.org/ redirects to https://code.google.com/p/formalchemy/
- https://code.google.com/p/formalchemy/ says: "Code has moved: FormAlchemy is now hosted on GitHub"
- The FormAlchemy GitHub repo is https://github.com/FormAlchemy/formalchemy
