### PR TITLE
Add Visualization section with sadisplay, sqlalchemy_schemadisplay.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -280,9 +280,13 @@ sqlalchemy-crosstab-postgresql_
 Visualizations
 --------------
 
+sadisplay_
+   Simple package for describing SQLAlchemy schema and display raw database tables by reflecting feature.
+
 sqlalchemy_schemadisplay_
    This module generates images from SQLAlchemy models.
 
+.. _sadisplay: https://bitbucket.org/estin/sadisplay
 .. _sqlalchemy_schemadisplay: https://github.com/fschulze/sqlalchemy_schemadisplay
 
 


### PR DESCRIPTION
Added [sqlalchemy_schemadisplay](https://github.com/fschulze/sqlalchemy_schemadisplay) into Other section. Would it be better if it has separated to another section for graphing/documenting tools?
