### PR TITLE
Changed the Recipes URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -302,7 +302,7 @@ sqlakeyset_
 Recipes
 -------
 
-* https://bitbucket.org/zzzeek/sqlalchemy/wiki/UsageRecipes
+* https://github.com/sqlalchemy/sqlalchemy/wiki/UsageRecipes
 
 
 Serialization and deserialization


### PR DESCRIPTION
The current URL is pointed to the Bitbucket Mirror of SQLAlchemy which doesn't have the Wiki enabled. Pointed the URL to the Github Wiki