### PR TITLE
Add pytest-mrt to Testing section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,10 +339,16 @@ mixer_
    Generate fake data and create random fixtures for testing in SQLAlchemy
    and many other Python ORM systems.
 
+pytest-mrt_
+   pytest plugin that tests whether Alembic migrations are safely reversible.
+   Runs the actual upgrade/downgrade cycle with real data and does static
+   analysis on migration files.
+
 
 .. _charlatan: https://github.com/uber/charlatan
 .. _factory_boy: https://github.com/FactoryBoy/factory_boy
 .. _mixer: https://github.com/klen/mixer
+.. _pytest-mrt: https://github.com/croc100/pytest-mrt
 
 
 Thin Abstractions


### PR DESCRIPTION
I've been bitten a few times by Alembic migrations that applied cleanly but failed on rollback — missing downgrade(), DROP COLUMN that loses data permanently, no-op downgrades that do nothing. Built pytest-mrt to catch these before they hit production.

It does two things: static analysis on migration files (44 patterns, no database needed), and dynamic verification that actually runs the up/down/up cycle against a real database and checks that schema and data survive the round trip.

- PyPI: https://pypi.org/project/pytest-mrt/
- MIT, actively maintained