### PR TITLE
Add dbconform to Database Migration Tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,9 +114,16 @@ sqlalchemy-migrate_
    Inspired by Ruby on Rails' migrations, SQLAlchemy Migrate provides
    a way to deal with database schema changes in SQLAlchemy projects.
 
+dbconform_
+   Detects and corrects SQLAlchemy schema drift against a live database
+   without migration history or files. Particularly useful when migration
+   history has diverged from reality, or when enforcing schema conformance
+   at application startup.
+
 .. _Alembic: https://alembic.readthedocs.io/
 .. _alembic-git-revisions: https://github.com/Mergifyio/alembic-git-revisions
 .. _sqlalchemy-migrate: https://sqlalchemy-migrate.readthedocs.io/
+.. _dbconform: https://pypi.org/project/dbconform/
 
 
 Dialects


### PR DESCRIPTION
**dbconform** inspects a live database and alters it to match SQLAlchemy models — stateless schema conformance with no migration history required. Fills a gap not covered by Alembic or sqlalchemy-migrate.

Links if you need them:
* https://pypi.org/project/dbconform/
* https://github.com/brian-pond/dbconform

Thank you!  :smiley: 
