### PR TITLE
Add queryspy to Profilers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -316,10 +316,20 @@ nplusone_
    nplusone detects unnecessary queries caused by lazy loading and unused eager loading.
    Integrates with Flask-SQLAlchemy.
 
+queryspy_
+   Detect N+1 access patterns and enforce query budgets in SQLAlchemy 2.0,
+   sync and async.
+
+   Names the line of application code responsible and suggests the loader
+   option that fixes it. Provides pytest assertions and a ``--queryspy-strict``
+   gate, an ASGI middleware with a per-request debug panel, and SARIF output
+   for GitHub code scanning.
+
 .. _flask_debugtoolbar: https://github.com/flask-debugtoolbar/flask-debugtoolbar
 .. _pyramid_debugtoolbar: https://github.com/Pylons/pyramid_debugtoolbar
 .. _SQLTap: https://github.com/inconshreveable/sqltap
 .. _nplusone: https://github.com/jmcarp/nplusone
+.. _queryspy: https://github.com/sqla-native/queryspy
 
 
 Query helpers


### PR DESCRIPTION
N+1 and query-budget detection for SQLAlchemy 2.0, sync and async. It reports the line of application code responsible and the loader option that fixes it, and ships pytest assertions, an ASGI middleware with a per-request debug panel, and SARIF output for GitHub code scanning.

Placed next to nplusone, the closest existing entry. It differs in being SQLAlchemy-only, built on the public `do_orm_execute` event rather than patching ORM internals, and supporting `AsyncSession`. It does **not** detect unused eager loading, which nplusone does — SQLAlchemy exposes no read event for an already-loaded attribute.

Disclosure: I wrote it.